### PR TITLE
Update fizzbuzz.adoc to explain the usage of null in the solution

### DIFF
--- a/src/docs/asciidoc/fizzbuzz.adoc
+++ b/src/docs/asciidoc/fizzbuzz.adoc
@@ -100,6 +100,9 @@ fizzbuzz = zipWith combine pattern [1..] where
                              then show number
                              else word
 ----
+NOTE: The use of 'null' in the code above does not refer to the null
+      pointer reference but to a function called 'null' which returns
+      true if it's argument is an empty list (eg. a blank string).
 
 These infinite productions are very versatile to use.
 We have already seen twice how to combine them, but they


### PR DESCRIPTION
When reading the book, it warns you that "In Frege, there is no null and thus there are no NullPointerExceptions any more!" before reaching this code sample; however it's a bit odd to see the "null" function being used, the proposal is to add a note to explain it's not a null pointer reference but a function called null.
