### PR TITLE
Turn on syntax highlighting

### DIFF
--- a/src/docs/asciidoc/incremental_episode4.adoc
+++ b/src/docs/asciidoc/incremental_episode4.adoc
@@ -54,6 +54,7 @@ Now, what happens if we go parallel and use `mapP` (the parallel version of `map
 instead of `map`? Here is the type signature of `mapP`:
 
 .The signature of _mapP_
+[source,haskell]
 ----
 mapP :: ( α -> β ) -> [α] -> [β]
 ----


### PR DESCRIPTION
Not so meaningful, just for consistency with the above signature of `map`.
