### PR TITLE
Remove a suspicious paragraph

### DIFF
--- a/src/docs/asciidoc/what.adoc
+++ b/src/docs/asciidoc/what.adoc
@@ -70,14 +70,6 @@ The String representation of a number is not always made up from
 digits only. Developers are usually aware that there are dots, minus, and the `E` character
 to consider but they often forget about `Infinity` and `NaN` (not a number).
 
-`Double` even goes around some problematic cases
-where fractions would not properly add up due to lack of precision:
-
-.Fractions add up
-----
-1 / (1 - 1/3 + 2/3) -- Infinity
-----
-
 And how do we calculate with Infinity? Well, when you add to infinity,
 the result is equally infinite. You can even add infinities to infinities.
 Division is not defined, though.


### PR DESCRIPTION
First of all, `1 / (1 - 1/3 + 2/3) -- Infinity` is not mathematically correct. Even if we revise it into `1 / (1 - 1/6 - 5/6)` and get `Infinity`, it doesn't show that `Double` "goes around" the case. The error should remain yet, just be concealed by rounding the machine-epsilon.

In addition, as I (and @Ingo60) mentioned in the issue #6, the behavior is from not Frege-specific but the IEEE 754. 

IMHO, the paragraph can lead us to misunderstanding, I guess.