### PR TITLE
Fix a Froogle query for joined

### DIFF
--- a/src/docs/asciidoc/fizzbuzz_reconstructed.adoc
+++ b/src/docs/asciidoc/fizzbuzz_reconstructed.adoc
@@ -270,4 +270,4 @@ Many thanks to Daniel Kröni for many inspiring discussions and suggestions.
 === References
 [horizontal]
 Froogle::
-Lookup `joined` by type: http://hoogle.haskell.org:8081/?hoogle=%5BString%5D%20-%3E%20String&scope=null
+Lookup `joined` by type: http://hoogle.haskell.org:8081/?hoogle=%5BString%5D%20-%3E%20String


### PR DESCRIPTION
I'm afraid that the last parameter hinders search (returns only `requireNonNullβ`.)